### PR TITLE
Fix for '@angular/http' module not found error in latest angular (7+)

### DIFF
--- a/src/auto-complete.service.ts
+++ b/src/auto-complete.service.ts
@@ -1,13 +1,13 @@
 ﻿import { Injectable, PLATFORM_ID, Inject } from '@angular/core';
 import { isPlatformBrowser, isPlatformServer } from '@angular/common';
 import { GlobalRef } from './windowRef.service';
-import { Http } from '@angular/http';
+import { HttpClient } from '@angular/common/http';
 import { LocalStorageService } from './storage.service';
 import 'rxjs/Rx';
 
 @Injectable()
 export class AutoCompleteSearchService {
-  constructor(private _http: Http, @Inject(PLATFORM_ID) private platformId: Object,
+  constructor(private _http: HttpClient, @Inject(PLATFORM_ID) private platformId: Object,
   private _global: GlobalRef, private _localStorageService: LocalStorageService) {
 
   }

--- a/src/ng-4-geoautocomplete.module.ts
+++ b/src/ng-4-geoautocomplete.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { AutoCompleteComponent } from './auto-complete.component';
 import { AutoCompleteSearchService } from './auto-complete.service';
@@ -12,7 +12,7 @@ import { GlobalRef, BrowserGlobalRef } from './windowRef.service';
   ],
   imports: [
     CommonModule,
-    HttpModule,
+    HttpClientModule,
     FormsModule
   ],
   exports: [


### PR DESCRIPTION
Fix for **Module not found: Error: Can't resolve '@angular/http'**